### PR TITLE
Fix image typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
 			<a href="#s1-divider" class="navbar-responsive-hide navbar-item">Home</a>
 			<a href="#s3-divider" class="navbar-responsive-hide navbar-item">Modules</a>
 			<a href="https://github.com/Jax-Core/JaxCore" class="navbar-responsive-hide navbar-item navbar-icon">
-				<img alt="Github icon" class="navbar-responsive-hide" src="/img/Github.png"></img>
+				<img alt="GitHub icon" class="navbar-responsive-hide" src="/img/GitHub.png"></img>
 			</a>
 			<a href="https://discord.gg/JmgehPSDD6" class="navbar-responsive-hide navbar-item navbar-icon">
 				<img alt="Discord icon" class="navbar-responsive-hide" src="/img/Discord.png"></img>


### PR DESCRIPTION
Apparently, HTML is so strict that the GitHub image isn't working correctly because of referring to `/img/Github.png`, but the actual file is `/img/GitHub.png`.